### PR TITLE
bring back html parsing of markdown entries

### DIFF
--- a/src/markdown-render.tsx
+++ b/src/markdown-render.tsx
@@ -3,14 +3,11 @@ import { Source } from "@nteract/presentational-components";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
-import htmlParser = require("react-markdown/plugins/html-parser");
-
 import RemarkMathPlugin from "./remark-math";
 import AttachmentTransformer, {
   Attachments,
 } from "./attachment/attachment-transformer";
 
-const parseHTML = htmlParser();
 interface MarkDownRenderProps extends ReactMarkdown.ReactMarkdownProps {
   attachments?: Attachments;
 }

--- a/src/markdown-render.tsx
+++ b/src/markdown-render.tsx
@@ -3,11 +3,14 @@ import { Source } from "@nteract/presentational-components";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
+import htmlParser = require("react-markdown/plugins/html-parser");
+
 import RemarkMathPlugin from "./remark-math";
 import AttachmentTransformer, {
   Attachments,
 } from "./attachment/attachment-transformer";
 
+const parseHTML = htmlParser();
 interface MarkDownRenderProps extends ReactMarkdown.ReactMarkdownProps {
   attachments?: Attachments;
 }
@@ -39,7 +42,7 @@ const MarkdownRender = (props: MarkDownRenderProps) => {
       ...props.renderers,
     },
     plugins: [RemarkMathPlugin],
-    astPlugins: [AttachmentTransformer(props.attachments)],
+    astPlugins: [AttachmentTransformer(props.attachments), parseHTML],
   };
   return <ReactMarkdown {...newProps} />;
 };

--- a/src/markdown-render.tsx
+++ b/src/markdown-render.tsx
@@ -42,7 +42,7 @@ const MarkdownRender = (props: MarkDownRenderProps) => {
       ...props.renderers,
     },
     plugins: [RemarkMathPlugin],
-    astPlugins: [AttachmentTransformer(props.attachments), props.astPlugins],
+    astPlugins: [AttachmentTransformer(props.attachments), ...props.astPlugins],
   };
   return <ReactMarkdown {...newProps} />;
 };

--- a/src/markdown-render.tsx
+++ b/src/markdown-render.tsx
@@ -42,7 +42,7 @@ const MarkdownRender = (props: MarkDownRenderProps) => {
       ...props.renderers,
     },
     plugins: [RemarkMathPlugin],
-    astPlugins: [AttachmentTransformer(props.attachments), parseHTML],
+    astPlugins: [AttachmentTransformer(props.attachments), props.astPlugins],
   };
   return <ReactMarkdown {...newProps} />;
 };

--- a/types/react-markdown/index.d.ts
+++ b/types/react-markdown/index.d.ts
@@ -1,3 +1,0 @@
-declare module "react-markdown/plugins/html-parser" {
-  export default function getHtmlParserPlugin(config: any, props: any): any;
-}

--- a/types/react-markdown/index.d.ts
+++ b/types/react-markdown/index.d.ts
@@ -1,0 +1,3 @@
+declare module "react-markdown/plugins/html-parser" {
+  export default function getHtmlParserPlugin(config: any, props: any): any;
+}


### PR DESCRIPTION
This allows for rendering HTML that is embedded in a Markdown cell or output. We started noticing this in some papermill output notebooks that used a simple `<span` tag with styling.

Alternatively, we could fold in `astPlugins` overrides more directly than the current `...props` splat here.